### PR TITLE
Do not upgrade all Ubuntu packages in GitHub CI builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,6 @@ jobs:
         run: |
           sudo dpkg --add-architecture i386
           sudo apt-get update
-          sudo apt-get dist-upgrade -o APT::Immediate-Configure=0 # Avoid configuration error later
           sudo apt-get --assume-yes install \
             automake bc bsdmainutils bzip2 curl cvs default-jre \
             g++-multilib git jing libarchive-tools \


### PR DESCRIPTION
Remove `apt-get dist-upgrade` command to not get new untested packages which
could lead to issues.